### PR TITLE
SMS - data_coding - unicode

### DIFF
--- a/src/direct7/sms.py
+++ b/src/direct7/sms.py
@@ -28,7 +28,7 @@ class SMS:
                 "recipients": message.get("recipients", []),
                 "content": message.get("content", ""),
                 "msg_type": "text",
-                "data_coding": "unicode" if message.unicode else "text"
+                "data_coding": "unicode" if message.get("unicode") is True else "text"
             }
             for message in args
         ]


### PR DESCRIPTION
Related to #5

Update `data_coding` attribute assignment in `src/direct7/sms.py` to use `message.get("unicode")`.

* Replace `message.unicode` with `message.get("unicode") is True` in the `data_coding` attribute assignment.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/d7networks/direct7-python-sdk/pull/7?shareId=40635c72-5076-4094-bee7-883f9bf6edac).