### PR TITLE
Fix docstring for send_messages method in SMS class

### DIFF
--- a/src/direct7/sms.py
+++ b/src/direct7/sms.py
@@ -16,7 +16,7 @@ class SMS:
                         - recipients: list - Mobile Numbers to send SMS separated by comma in an array.
                         - content: str - The message content being sent.
                         - msg_type: str - Type of the message (e.g., "text").
-                        - data_coding: str - Coding type for the message (e.g., "text" or "unicode").
+                        - unicode: boolean - true content is not gsm03.38 safe
         :param originator: str - The Sender/Header of a message.
         :param report_url: str - Receive delivery status.
         :return:
@@ -28,7 +28,7 @@ class SMS:
                 "recipients": message.get("recipients", []),
                 "content": message.get("content", ""),
                 "msg_type": "text",
-                "data_coding": "unicode" if message.unicode else "text"
+                "data_coding": "unicode" if message.get("unicode", False) else "text"
             }
             for message in args
         ]


### PR DESCRIPTION
Fixes #6

Update the `send_messages` method to use the `unicode` argument instead of `data_coding`.

* Update the docstring of the `send_messages` method to reflect the use of the `unicode` argument.
* Set the `data_coding` value to "unicode" if `unicode` is `True`, otherwise set it to "text".
* Modify the message dictionary to use `message.get("unicode", False)` for determining the `data_coding` value.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/d7networks/direct7-python-sdk/pull/8?shareId=79adace4-66ae-42b6-93d7-6f818d6cdcbe).